### PR TITLE
Block network calls from tests and linting

### DIFF
--- a/app/election/api_views.py
+++ b/app/election/api_views.py
@@ -1,7 +1,7 @@
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from .models import State, StateInformationFieldType
-from .serializers import StateFieldSerializer, StateSerializer, FieldSerializer
+from .serializers import FieldSerializer, StateFieldSerializer, StateSerializer
 
 
 class StateViewSet(ReadOnlyModelViewSet):
@@ -9,11 +9,12 @@ class StateViewSet(ReadOnlyModelViewSet):
     serializer_class = StateSerializer
     queryset = State.objects.all()
 
+
 class StateFieldsViewSet(ReadOnlyModelViewSet):
     model = StateInformationFieldType
-    
+
     queryset = StateInformationFieldType.objects.all()
-    lookup_field = 'slug'
+    lookup_field = "slug"
 
     def list(self, request):
         self.serializer_class = FieldSerializer

--- a/app/election/forms.py
+++ b/app/election/forms.py
@@ -30,8 +30,8 @@ class StateInformationManageForm(forms.ModelForm):
 
     def clean_text(self) -> str:
         text = self.cleaned_data["text"]
-        if text == '':
-            return ''
+        if text == "":
+            return ""
         if self.field_format == StateFieldFormats.URL:
             validator = URLValidator()
             validator(text)

--- a/app/election/serializers.py
+++ b/app/election/serializers.py
@@ -19,6 +19,7 @@ class StateInfoSerializer(serializers.ModelSerializer):
             result["value"] = instance.text.lower() == "true"
         return result
 
+
 class FieldStateSerializer(serializers.ModelSerializer):
     class Meta:
         model = StateInformation
@@ -50,7 +51,7 @@ class FieldSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
 
 
 class StateFieldSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
-    states =  FieldStateSerializer(source="stateinformation_set", many=True)
+    states = FieldStateSerializer(source="stateinformation_set", many=True)
 
     class Meta:
         model = StateInformationFieldType

--- a/app/register/api_views.py
+++ b/app/register/api_views.py
@@ -77,4 +77,3 @@ class StatusViewSet(UpdateModelMixin, GenericViewSet):
     model = Registration
     serializer_class = StatusSerializer
     queryset = Registration.objects.filter(status=TurnoutRegistrationStatus.INCOMPLETE)
-

--- a/app/register/serializers.py
+++ b/app/register/serializers.py
@@ -9,7 +9,11 @@ from rest_framework.fields import empty
 
 from common import enums
 from common.utils.fields import RequiredBooleanField
-from common.validators import state_code_validator, zip_validator, must_be_true_validator
+from common.validators import (
+    must_be_true_validator,
+    state_code_validator,
+    zip_validator,
+)
 from election.choices import STATES
 from multi_tenant.mixins_serializers import PartnerSerializerMixin
 
@@ -80,8 +84,12 @@ class RegistrationSerializer(
     title = serializers.CharField(required=True)
     previous_title = serializers.CharField(required=True)
     state_id_number = serializers.CharField(required=False)
-    is_18_or_over = RequiredBooleanField(required=False, validators=[must_be_true_validator])
-    us_citizen = RequiredBooleanField(required=False, validators=[must_be_true_validator])
+    is_18_or_over = RequiredBooleanField(
+        required=False, validators=[must_be_true_validator]
+    )
+    us_citizen = RequiredBooleanField(
+        required=False, validators=[must_be_true_validator]
+    )
 
     class Meta:
         model = Registration
@@ -118,4 +126,3 @@ class StatusSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
                 f"Registration status can only be {enums.TurnoutRegistrationStatus.OVR_REFERRED.value}"
             )
         return value
-

--- a/app/register/tests/test_api_views.py
+++ b/app/register/tests/test_api_views.py
@@ -5,7 +5,12 @@ import pytest
 from model_bakery import baker
 from rest_framework.test import APIClient
 
-from common.enums import TurnoutRegistrationStatus, PersonTitle, PoliticalParties, RaceEthnicity
+from common.enums import (
+    PersonTitle,
+    PoliticalParties,
+    RaceEthnicity,
+    TurnoutRegistrationStatus,
+)
 from election.models import State
 from multi_tenant.models import Client
 from register.models import Registration
@@ -31,7 +36,7 @@ VALID_REGISTRATION = {
     "is_18_or_over": True,
     "state_id_number": "FOUNDER123",
     "party": "Other",
-    "race_ethnicity": "White"
+    "race_ethnicity": "White",
 }
 REGISTER_API_ENDPOINT_INCOMPLETE = "/v1/registration/register/?incomplete=true"
 
@@ -202,7 +207,9 @@ def test_invalid_state(requests_mock):
 @pytest.mark.django_db
 def test_update_status(requests_mock):
     client = APIClient()
-    register_response = client.post(REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION)
+    register_response = client.post(
+        REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION
+    )
     assert register_response.status_code == 200
     assert "uuid" in register_response.json()
 
@@ -224,7 +231,9 @@ def test_update_status(requests_mock):
 @pytest.mark.django_db
 def test_invalid_update_status(requests_mock):
     client = APIClient()
-    register_response = client.post(REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION)
+    register_response = client.post(
+        REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION
+    )
     assert register_response.status_code == 200
     assert "uuid" in register_response.json()
 
@@ -233,19 +242,21 @@ def test_invalid_update_status(requests_mock):
     assert registration.status == TurnoutRegistrationStatus.INCOMPLETE
 
     invalid_update_status = copy(STATUS_REFER_OVR)
-    invalid_update_status['status'] = "Invalid"
+    invalid_update_status["status"] = "Invalid"
 
     status_api_url = STATUS_API_ENDPOINT.format(uuid=registration.uuid)
     status_response = client.patch(status_api_url, invalid_update_status)
     assert status_response.status_code == 400
-    assert status_response.json() == {"status":["\"Invalid\" is not a valid choice."]}
+    assert status_response.json() == {"status": ['"Invalid" is not a valid choice.']}
     assert registration.status == TurnoutRegistrationStatus.INCOMPLETE
 
 
 @pytest.mark.django_db
 def test_bad_update_status(requests_mock):
     client = APIClient()
-    register_response = client.post(REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION)
+    register_response = client.post(
+        REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION
+    )
     assert register_response.status_code == 200
     assert "uuid" in register_response.json()
 
@@ -254,11 +265,12 @@ def test_bad_update_status(requests_mock):
     assert registration.status == TurnoutRegistrationStatus.INCOMPLETE
 
     bad_update_status = copy(STATUS_REFER_OVR)
-    bad_update_status['status'] = "SentPDF"
+    bad_update_status["status"] = "SentPDF"
 
     status_api_url = STATUS_API_ENDPOINT.format(uuid=registration.uuid)
     status_response = client.patch(status_api_url, bad_update_status)
     assert status_response.status_code == 400
-    assert status_response.json() == {"status": ["Registration status can only be ReferOVR"]}
+    assert status_response.json() == {
+        "status": ["Registration status can only be ReferOVR"]
+    }
     assert registration.status == TurnoutRegistrationStatus.INCOMPLETE
-

--- a/app/register/tests/test_api_views.py
+++ b/app/register/tests/test_api_views.py
@@ -56,7 +56,7 @@ def test_get_request_disallowed():
     assert response.json() == {"detail": 'Method "GET" not allowed.'}
 
 
-def test_blank_api_request(requests_mock):
+def test_blank_api_request():
     client = APIClient()
     response = client.post(REGISTER_API_ENDPOINT, {})
     assert response.status_code == 400
@@ -78,7 +78,7 @@ def test_blank_api_request(requests_mock):
 
 
 @pytest.mark.django_db
-def test_register_object_created(requests_mock, submission_task_patch):
+def test_register_object_created(submission_task_patch):
     client = APIClient()
 
     response = client.post(REGISTER_API_ENDPOINT, VALID_REGISTRATION)
@@ -117,7 +117,7 @@ def test_register_object_created(requests_mock, submission_task_patch):
 
 
 @pytest.mark.django_db
-def test_default_partner(requests_mock, submission_task_patch):
+def test_default_partner(submission_task_patch):
     client = APIClient()
 
     first_partner = Client.objects.first()
@@ -138,7 +138,7 @@ def test_default_partner(requests_mock, submission_task_patch):
 
 
 @pytest.mark.django_db
-def test_custom_partner(requests_mock, submission_task_patch):
+def test_custom_partner(submission_task_patch):
     client = APIClient()
 
     second_partner = baker.make_recipe("multi_tenant.client")
@@ -159,7 +159,7 @@ def test_custom_partner(requests_mock, submission_task_patch):
 
 
 @pytest.mark.django_db
-def test_invalid_partner_key(requests_mock, submission_task_patch):
+def test_invalid_partner_key(submission_task_patch):
     client = APIClient()
 
     first_partner = Client.objects.first()
@@ -180,7 +180,7 @@ def test_invalid_partner_key(requests_mock, submission_task_patch):
     )
 
 
-def test_not_us_citizen(requests_mock):
+def test_not_us_citizen():
     client = APIClient()
     not_citzen_register = copy(VALID_REGISTRATION)
     not_citzen_register["us_citizen"] = False
@@ -189,7 +189,7 @@ def test_not_us_citizen(requests_mock):
     assert response.json() == {"us_citizen": ["Must be true"]}
 
 
-def test_not_18_or_over(requests_mock):
+def test_not_18_or_over():
     client = APIClient()
     not_18_years_old_register = copy(VALID_REGISTRATION)
     not_18_years_old_register["is_18_or_over"] = False
@@ -198,7 +198,7 @@ def test_not_18_or_over(requests_mock):
     assert response.json() == {"is_18_or_over": ["Must be true"]}
 
 
-def test_invalid_zipcode(requests_mock):
+def test_invalid_zipcode():
     client = APIClient()
     bad_zip_register = copy(VALID_REGISTRATION)
     bad_zip_register["zipcode"] = "123"
@@ -207,7 +207,7 @@ def test_invalid_zipcode(requests_mock):
     assert response.json() == {"zipcode": ["Zip codes are 5 digits"]}
 
 
-def test_invalid_phone(requests_mock):
+def test_invalid_phone():
     client = APIClient()
     bad_phone_register = copy(VALID_REGISTRATION)
     bad_phone_register["phone"] = "123"
@@ -216,7 +216,7 @@ def test_invalid_phone(requests_mock):
     assert response.json() == {"phone": ["Enter a valid phone number."]}
 
 
-def test_invalid_state(requests_mock):
+def test_invalid_state():
     client = APIClient()
     bad_state_register = copy(VALID_REGISTRATION)
     bad_state_register["state"] = "ZZ"
@@ -226,7 +226,7 @@ def test_invalid_state(requests_mock):
 
 
 @pytest.mark.django_db
-def test_update_status(requests_mock):
+def test_update_status():
     client = APIClient()
     register_response = client.post(
         REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION
@@ -250,7 +250,7 @@ def test_update_status(requests_mock):
 
 
 @pytest.mark.django_db
-def test_invalid_update_status(requests_mock):
+def test_invalid_update_status():
     client = APIClient()
     register_response = client.post(
         REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION
@@ -273,7 +273,7 @@ def test_invalid_update_status(requests_mock):
 
 
 @pytest.mark.django_db
-def test_bad_update_status(requests_mock):
+def test_bad_update_status():
     client = APIClient()
     register_response = client.post(
         REGISTER_API_ENDPOINT_INCOMPLETE, VALID_REGISTRATION

--- a/app/register/tests/test_models.py
+++ b/app/register/tests/test_models.py
@@ -5,5 +5,7 @@ from register import models
 
 @pytest.mark.django_db
 def test_registration_str():
-    registration = models.Registration(first_name="John", last_name="Hancock", state_id="MA")
+    registration = models.Registration(
+        first_name="John", last_name="Hancock", state_id="MA"
+    )
     assert str(registration) == "Registration - John Hancock, MA"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -45,6 +45,7 @@ git+https://github.com/nickcatal/django-otp.git@b1d1a36008da5e2e161d3e550a91ae23
 qrcode==6.*
 requests-mock==1.7.*
 pytest-mock==2.0.*
+pytest-socket==0.3.*
 pytest-freezegun==0.4.*
 netifaces==0.10.*
 pdfrw==0.4

--- a/app/setup.cfg
+++ b/app/setup.cfg
@@ -3,6 +3,7 @@ DJANGO_SETTINGS_MODULE = turnout.settings
 filterwarnings =
     ignore::DeprecationWarning
 requests_mock_case_sensitive = True
+addopts = --disable-socket
 
 [mypy]
 plugins =


### PR DESCRIPTION
Some of our tests were making external network calls. By adding `pytest-socket` we can completely stop that from happening by having pytest raise an exception whenever an attempt is made to make an external network call.

Also added some mocking to stop these call attempts from happening.

Also there were some linting problems that arose over time that this cleans up.