### PR TITLE
Small tweaks to docs on running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ To run locally run `make up` then (while the server is up) in another shell run 
 
 To create a new superuser run `make createsuperuser` (while server is running)
 
-To run python tests, run `make test` (while server is running)
-
-To run python type checking, run `make mypy` (while server is running)
-
-To run python unit and integration tests, run `make testpy` (while server is running)
+To run python tests and type checking, run `make test` (while server is running). You can also run just the tests with `make testpy` and just the type checking with `make mypy`.
 
 To clean python files run `make lint` (while the server is running)
 


### PR DESCRIPTION
Clarifying that `make test` is the same as running `make testpy && make mypy`.