### PR TITLE
feature: integration: monitor external_tool_* sites

### DIFF
--- a/app/integration/datadog_synthetics.py
+++ b/app/integration/datadog_synthetics.py
@@ -1,0 +1,112 @@
+import copy
+import logging
+
+import datadog
+import requests
+from django.conf import settings
+
+from election.models import StateInformation
+
+logger = logging.getLogger("integration")
+
+MONITORS = {
+    "ovr": "external_tool_ovr",
+    "polling-place": "external_tool_polling_place",
+    "verify-status": "external_tool_verify_status",
+    "absentee-application": "external_tool_vbm_application",
+    "absentee-tracker": "external_tool_absentee_ballot_tracker",
+}
+
+TESTS_ENDPOINT = "https://api.datadoghq.com/api/v1/synthetics/tests"
+
+CREATE_TEMPLATE = {
+    "locations": ["aws:us-east-2", "aws:us-west-1", "aws:us-west-2"],
+    "name": "...",
+    "message": "",
+    "config": {
+        "request": {"url": "...", "method": "GET", "timeout": 30},
+        "assertions": [{"operator": "is", "type": "statusCode", "target": 200}],
+    },
+    "type": "api",
+    "options": {
+        "monitor_options": {
+            "notify_audit": False,
+            "locked": False,
+            "include_tags": True,
+            "new_host_delay": 300,
+            "notify_no_data": False,
+            "renotify_interval": 0,
+        },
+        "retry": {"count": 0, "interval": 300},
+        "min_location_failed": 1,
+        "min_failure_duration": 0,
+        "tick_every": 300,
+    },
+    "tags": ["env:external"],
+}
+
+
+def get_existing_synthetics():
+    r = {}
+    for test in datadog.api.Synthetics.get_all_tests()["tests"]:
+        r[test["name"]] = test
+    return r
+
+
+def update_group(prefix, slug, existing):
+    for item in StateInformation.objects.filter(field_type__slug=slug):
+        # some values are blank
+        if not item.text:
+            continue
+
+        name = f"{prefix}-{item.state_id}"
+
+        req = copy.deepcopy(CREATE_TEMPLATE)
+        req["name"] = name
+        req["config"]["request"]["url"] = item.text
+        req["tags"].append(f"type:{prefix}")
+
+        if name in existing:
+            old = existing[name]
+            del existing[name]
+            same = True
+            for k in ["options", "config", "name", "locations", "tags"]:
+                if old[k] != req[k]:
+                    same = False
+            if same:
+                continue
+            logger.info(f"Updating {name}")
+            response = requests.put(
+                f"{TESTS_ENDPOINT}/{old['public_id']}",
+                headers={
+                    "DD-API-KEY": settings.DATADOG_API_KEY,
+                    "DD-APPLICATION-KEY": settings.DATADOG_APPLICATION_KEY,
+                },
+                json=req,
+            )
+        else:
+            logger.info(f"Adding {name} {item.text}")
+            response = requests.post(
+                TESTS_ENDPOINT,
+                headers={
+                    "DD-API-KEY": settings.DATADOG_API_KEY,
+                    "DD-APPLICATION-KEY": settings.DATADOG_APPLICATION_KEY,
+                },
+                json=req,
+            )
+        if response.status_code != 200:
+            logger.warning(response.text)
+
+    for name, old in existing.items():
+        if name.startswith(prefix + "-"):
+            logger.info(f"Removing {name}")
+            datadog.api.Synthetics.delete_test(public_ids=[old["public_id"]])
+
+
+def sync():
+    datadog.initialize(
+        api_key=settings.DATADOG_API_KEY, app_key=settings.DATADOG_APPLICATION_KEY,
+    )
+    existing = get_existing_synthetics()
+    for prefix, slug in MONITORS.items():
+        update_group(prefix, slug, existing)

--- a/app/integration/tasks.py
+++ b/app/integration/tasks.py
@@ -27,3 +27,10 @@ def sync_registration_to_actionnetwork(pk: str) -> None:
 @shared_task
 def sync_actionnetwork():
     sync()
+
+
+@shared_task
+def sync_datadog_synthetics():
+    from .datadog_synthetics import sync
+
+    sync()

--- a/app/turnout/settings/core.py
+++ b/app/turnout/settings/core.py
@@ -204,6 +204,10 @@ USVF_SYNC = env.bool("USVF_SYNC", False)
 USVF_SYNC_HOUR = env.int("USVF_SYNC_HOUR", 6)
 USVF_SYNC_MINUTE = env.int("USVF_SYNC_MINUTE", 30)
 
+DATADOG_SYNTHETICS_SYNC = env.bool("DATADOG_SYNTHETICS_SYNC", default=False)
+DATADOG_SYNTHETICS_SYNC_HOUR = env.int("DATADOG_SYNTHETICS_SYNC_HOUR", default=5)
+DATADOG_SYNTHETICS_SYNC_MINUTE = env.int("DATADOG_SYNTHETICS_SYNC_HOUR", default=5)
+
 # This (daily?) sync is only to catch stragglers that don't sync in realtime.
 ACTIONNETWORK_SYNC = env.bool("ACTIONNETWORK_SYNC", False)
 ACTIONNETWORK_SYNC_HOUR = env.int("ACTIONNETWORK_SYNC_HOUR", 5)
@@ -234,6 +238,13 @@ if USVF_SYNC:
     CELERY_BEAT_SCHEDULE["trigger-usvf-sync"] = {
         "task": "official.tasks.sync_usvotefoundation",
         "schedule": crontab(minute=USVF_SYNC_MINUTE, hour=USVF_SYNC_HOUR),
+    }
+if DATADOG_SYNTHETICS_SYNC:
+    CELERY_BEAT_SCHEDULE["trigger-datadog-synthetics-sync"] = {
+        "task": "integration.tasks.sync_datadog_synthetics",
+        "schedule": crontab(
+            minute=DATADOG_SYNTHETICS_SYNC_MINUTE, hour=DATADOG_SYNTHETICS_SYNC_HOUR
+        ),
     }
 if ACTIONNETWORK_SYNC:
     CELERY_BEAT_SCHEDULE["trigger-actionnetwork-sync"] = {
@@ -353,6 +364,8 @@ CLOUDFLARE_ZONE = env.str("CLOUDFLARE_ZONE", default="")
 #### DATADOG CONFIGURATION
 
 ddtrace.tracer.set_tags({"build": BUILD})
+DATADOG_API_KEY = env.str("DATADOG_API_KEY", default=None)
+DATADOG_APPLICATION_KEY = env.str("DATADOG_APPLICATION_KEY", default=None)
 
 #### END DATADOG CONFIGURATION
 


### PR DESCRIPTION
Push these to datadog synthetics so that we gather uptime data.

- [ ] add on/off flag to ecs env

Next steps (post- this PR):
- wait for twitter (group) dev account to be approved
- calculate update over given period based on ``.../results`` request (unfortunately datadog does not provide summary stats for you--it's all calculated client-side)
- sort out when the twitter bot should tweet (when a site goes down?  when it comes back up, so that we have a new downtime percentage?  after its been down for X long?  etc.)