### PR TITLE
election: add endpoint to redirect to state tools

### DIFF
--- a/app/election/api_urls.py
+++ b/app/election/api_urls.py
@@ -1,10 +1,16 @@
+from django.urls import path
 from rest_framework import routers
 
-from .api_views import StateFieldsViewSet, StateViewSet
+from .api_views import StateExternalToolRedirectView, StateFieldsViewSet, StateViewSet
 
 router = routers.SimpleRouter()
 router.register(r"state", StateViewSet)
 router.register(r"field", StateFieldsViewSet)
 
 app_name = "api_election"
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path(
+        "state-redirect/<str:state>/<str:slug>/",
+        StateExternalToolRedirectView.as_view(),
+    ),
+]

--- a/app/election/api_views.py
+++ b/app/election/api_views.py
@@ -3,6 +3,7 @@ from django.views.generic.base import RedirectView
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from cdn.views_mixin import CDNCachedView
+from register.custom_ovr_links import get_custom_ovr_link
 
 from .models import State, StateInformation, StateInformationFieldType
 from .serializers import FieldSerializer, StateFieldSerializer, StateSerializer
@@ -33,6 +34,11 @@ class StateExternalToolRedirectView(RedirectView):
     permanent = False
 
     def get_redirect_url(self, state, slug, **kwargs):
+        if slug == "external_tool_ovr":
+            custom = get_custom_ovr_link(state)
+            if custom:
+                return custom
+
         for field in StateInformation.objects.filter(
             state_id=state, field_type__slug=slug
         ):

--- a/app/election/api_views.py
+++ b/app/election/api_views.py
@@ -1,8 +1,10 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.views.generic.base import RedirectView
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from cdn.views_mixin import CDNCachedView
 
-from .models import State, StateInformationFieldType
+from .models import State, StateInformation, StateInformationFieldType
 from .serializers import FieldSerializer, StateFieldSerializer, StateSerializer
 
 
@@ -25,3 +27,31 @@ class StateFieldsViewSet(CDNCachedView, ReadOnlyModelViewSet):
     def retrieve(self, request, slug=None):
         self.serializer_class = StateFieldSerializer
         return super().retrieve(request, slug)
+
+
+class StateExternalToolRedirectView(RedirectView):
+    permanent = False
+
+    def get_redirect_url(self, state, slug, **kwargs):
+        for field in StateInformation.objects.filter(
+            state_id=state, field_type__slug=slug
+        ):
+            if field.text:
+                return field.text
+
+        SLUG_FALLBACK_URLS = {
+            "external_tool_verify_status": "https://voteamerica.com/am-i-registered-to-vote",
+            "external_tool_ovr": "https://voteamerica.com/register-to-vote",
+            "external_tool_vbm_application": "https://voteamerica.com/absentee-ballot",
+            "external_tool_polling_place": "https://www.voteamerica.com/where-is-my-polling-place",
+        }
+        if slug in SLUG_FALLBACK_URLS:
+            url = SLUG_FALLBACK_URLS[slug]
+            try:
+                state_obj = State.objects.get(code=state)
+                url += "-" + state_obj.url_suffix
+            except ObjectDoesNotExist:
+                pass
+            return url
+
+        return "https://voteamerica.com/"

--- a/app/election/models.py
+++ b/app/election/models.py
@@ -44,6 +44,10 @@ class State(TimestampModel):
             data[item.field_type.slug] = item.formal_format
         return data
 
+    @property
+    def url_suffix(self):
+        return self.name.lower().replace(" ", "-")
+
 
 class StateInformationFieldType(UUIDModel, TimestampModel):
     slug = models.SlugField("Name", max_length=50, unique=True)

--- a/app/register/api_views.py
+++ b/app/register/api_views.py
@@ -240,7 +240,7 @@ class RegistrationViewSet(IncompleteActionViewSet):
             sync_registration_to_actionnetwork.delay(registration.uuid)
 
     def after_create(self, action_object):
-        custom_link = get_custom_ovr_link(action_object)
+        custom_link = get_custom_ovr_link(action_object.state.code, action_object)
 
         if custom_link:
             action_object.custom_ovr_link = custom_link

--- a/app/register/custom_ovr_links/__init__.py
+++ b/app/register/custom_ovr_links/__init__.py
@@ -5,11 +5,13 @@ from .co import get_custom_ovr_link_co
 from .wa import get_custom_ovr_link_wa
 
 
-def get_custom_ovr_link(registration: Registration) -> Optional[str]:
-    if registration.state.code == "CO":
+def get_custom_ovr_link(
+    state: str, registration: Optional[Registration]=None
+) -> Optional[str]:
+    if state == "CO":
         return get_custom_ovr_link_co(registration)
 
-    if registration.state.code == "WA":
+    if state == "WA":
         return get_custom_ovr_link_wa(registration)
 
     return None

--- a/app/register/custom_ovr_links/co.py
+++ b/app/register/custom_ovr_links/co.py
@@ -5,8 +5,13 @@ from django.conf import settings
 from ..models import Registration
 
 
-def get_custom_ovr_link_co(registration: Registration) -> Optional[str]:
+def get_custom_ovr_link_co(
+    registration: Optional[Registration] = None,
+) -> Optional[str]:
     if settings.REGISTER_CO_VRD_ENABLED:
-        return f"https://www.sos.state.co.us/voter/pages/pub/olvr/verifyNewVoter.xhtml?vrdid={settings.REGISTER_CO_VRD_ID}&campaign={registration.uuid}"
+        url = f"https://www.sos.state.co.us/voter/pages/pub/olvr/verifyNewVoter.xhtml?vrdid={settings.REGISTER_CO_VRD_ID}"
+        if registration:
+            url += f"&campaign={registration.uuid}"
+        return url
     else:
         return None

--- a/app/register/custom_ovr_links/wa.py
+++ b/app/register/custom_ovr_links/wa.py
@@ -5,7 +5,9 @@ from django.conf import settings
 from ..models import Registration
 
 
-def get_custom_ovr_link_wa(registration: Registration) -> Optional[str]:
+def get_custom_ovr_link_wa(
+    registration: Optional[Registration] = None,
+) -> Optional[str]:
     if settings.REGISTER_WA_VRD_ENABLED:
         return f"https://olvr.votewa.gov/default.aspx?Org={settings.REGISTER_WA_VRD_ID}"
     else:


### PR DESCRIPTION
This will let us put links in emails that send users directly to the state
tools.  This is desirable for things like having the user verify their voter
registration went through--we want them to use the authoritative state tool
and not our laggy check.  And since they're already a user there is no
point in re-collecting their info.

If there is no state tool, redirect to our internal tool.

Note: for CO we are passing only 1 of the 2 tracking args.. is this okay, or should we pass none?