### PR TITLE
Fix capitalization of field in Lob emails

### DIFF
--- a/app/register/templates/register/email/file_notification.html
+++ b/app/register/templates/register/email/file_notification.html
@@ -44,7 +44,7 @@ Just a few more steps to complete your voter registration.
 
 <hr><br>
 
-Your voter registration form must be <strong>{{ state_info.2020_registration_deadline_by_mail|markdownify|lower }}</strong>.<br><br>
+Your voter registration form must be: <strong>{{ state_info.2020_registration_deadline_by_mail|markdownify|capfirst }}</strong>.<br><br>
 
 Helpful hints:
 <ul style="margin-left:0;padding-left:0">

--- a/app/register/templates/register/email/print_and_forward_notification.html
+++ b/app/register/templates/register/email/print_and_forward_notification.html
@@ -44,7 +44,7 @@ Just a few more steps to complete your voter registration.
 
 <hr><br>
 
-Your voter registration form must be <strong>{{ state_info.2020_registration_deadline_by_mail|markdownify|lower }}</strong>.<br><br>
+Your voter registration form must be: <strong>{{ state_info.2020_registration_deadline_by_mail|markdownify|capfirst }}</strong>.<br><br>
 
 Helpful hints:
 <ul style="margin-left:0;padding-left:0">


### PR DESCRIPTION
Will be written as "Postmarked by October 11, 2020" or "postmarked by October 11, 2020" in the Admin Tool. Having the "by" be capitalized seems fine, if that's what capfirst does?

Follow-on to: https://github.com/vote/turnout/pull/441 and https://github.com/vote/turnout/pull/442

Story: https://app.clubhouse.io/turnout2020/story/2518/front-end-designs-mockups-for-print-and-mail-api

WAS: (same in Lob email and other register emails)
![image](https://user-images.githubusercontent.com/1372946/91794807-d2c3e580-ebd0-11ea-9f15-7e0ed8b306e2.png)


***

I'm pretty rusty on Django, I'm not sure how to test this locally. I'm thinking it will return `Postmarked by October 11, 2020` or `Postmarked By October 11, 2020` 

What I really wanted to do was lowercase the first character of the strong only - since we aren't sure if the admin tool will be entered as `Postmarked by October 11, 2020` or `postmarked by October 11, 2020`. But added a colon here as a "quick fix".