### PR TITLE
usvf: do not use bulk_update()

### DIFF
--- a/app/official/usvf.py
+++ b/app/official/usvf.py
@@ -238,9 +238,9 @@ def scrape_offices(session: requests.Session, regions: Sequence[Region]) -> None
                 if getattr(obj, k) != getattr(r, k):
                     setattr(obj, k, getattr(r, k))
                     changed = True
-                if changed:
-                    logger.info(f"Updated {obj}")
-                    obj.save()
+            if changed:
+                logger.info(f"Updated {obj}")
+                obj.save()
 
     slow_bulk_update(
         Office,

--- a/app/official/usvf.py
+++ b/app/official/usvf.py
@@ -244,13 +244,13 @@ def scrape_offices(session: requests.Session, regions: Sequence[Region]) -> None
 
     slow_bulk_update(
         Office,
-        'external_id',
+        "external_id",
         [x[1] for x in offices_dict.values() if x[0] == Action.UPDATE],
         ["hours", "notes"],
     )
     slow_bulk_update(
         Address,
-        'external_id',
+        "external_id",
         [x[1] for x in addresses_dict.values() if x[0] == Action.UPDATE],
         [
             "address",


### PR DESCRIPTION
This fails without batch_size on aurora. And even if it didn't, it
doesn't update modified_at, which is very handy. Open code our own
version.

Also.. this version seems to be faster??

Note that adding batch_size=100 to the bulk_update() would probably also work, but that doesn't get us the modified_at update.