### PR TITLE
Add /v1/people/opt-out/ endpoint for email and/or phone

### DIFF
--- a/app/integration/tasks.py
+++ b/app/integration/tasks.py
@@ -66,10 +66,17 @@ def sync_subscriber_to_actionnetwork(pk: str) -> None:
 
 
 @shared_task(queue="actionnetwork")
-def unsubscribe_phone_from_actionnetwork(phone: str) -> None:
+def unsubscribe_email_from_actionnetwork(email: str) -> None:
+    from .actionnetwork import unsubscribe_email
+
+    unsubscribe_email(email)
+
+
+@shared_task(queue="actionnetwork")
+def unsubscribe_phone_from_actionnetwork(phone: str, email: str = None) -> None:
     from .actionnetwork import unsubscribe_phone
 
-    unsubscribe_phone(phone)
+    unsubscribe_phone(phone, email=email)
 
 
 @shared_task(queue="actionnetwork")

--- a/app/people/api_urls.py
+++ b/app/people/api_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .api_views import OptOutView
+
+app_name = "api_people"
+urlpatterns = [
+    path("opt-out/", OptOutView.as_view()),
+]

--- a/app/people/api_views.py
+++ b/app/people/api_views.py
@@ -1,0 +1,30 @@
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from integration.tasks import (
+    unsubscribe_email_from_actionnetwork,
+    unsubscribe_phone_from_actionnetwork,
+)
+
+from .serializers import OptInOutSerializer
+
+
+class OptOutView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request, format=None):
+        serializer = OptInOutSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        phone = serializer.validated_data.get("phone")
+        email = serializer.validated_data.get("email")
+
+        if email:
+            unsubscribe_email_from_actionnetwork.delay(email)
+            if phone:
+                unsubscribe_phone_from_actionnetwork.delay(str(phone), email)
+        elif phone:
+            unsubscribe_phone_from_actionnetwork.delay(str(phone))
+
+        return Response()

--- a/app/people/serializers.py
+++ b/app/people/serializers.py
@@ -1,0 +1,7 @@
+from phonenumber_field.serializerfields import PhoneNumberField
+from rest_framework import serializers
+
+
+class OptInOutSerializer(serializers.Serializer):
+    phone = PhoneNumberField(required=False)
+    email = serializers.EmailField(required=False)

--- a/app/people/tests/test_api_views.py
+++ b/app/people/tests/test_api_views.py
@@ -1,0 +1,41 @@
+from rest_framework.test import APIClient
+
+UNSUB_API_ENDPOINT = "/v1/people/opt-out/"
+
+
+def test_unsubscribe_email(mocker):
+    unsub_phone = mocker.patch("people.api_views.unsubscribe_phone_from_actionnetwork")
+    unsub_email = mocker.patch("people.api_views.unsubscribe_email_from_actionnetwork")
+
+    client = APIClient()
+    response = client.post(UNSUB_API_ENDPOINT, {"email": "foo@bar.com"})
+
+    assert response.status_code == 200
+    unsub_email.delay.assert_called_once_with("foo@bar.com")
+    unsub_phone.delay.assert_not_called()
+
+
+def test_unsubscribe_phone(mocker):
+    unsub_phone = mocker.patch("people.api_views.unsubscribe_phone_from_actionnetwork")
+    unsub_email = mocker.patch("people.api_views.unsubscribe_email_from_actionnetwork")
+
+    client = APIClient()
+    response = client.post(UNSUB_API_ENDPOINT, {"phone": "+19515551212"})
+
+    assert response.status_code == 200
+    unsub_email.delay.assert_not_called()
+    unsub_phone.delay.assert_called_once_with("(951) 555-1212")
+
+
+def test_unsubscribe_both(mocker):
+    unsub_phone = mocker.patch("people.api_views.unsubscribe_phone_from_actionnetwork")
+    unsub_email = mocker.patch("people.api_views.unsubscribe_email_from_actionnetwork")
+
+    client = APIClient()
+    response = client.post(
+        UNSUB_API_ENDPOINT, {"email": "foo@bar.com", "phone": "+19515551212"}
+    )
+
+    assert response.status_code == 200
+    unsub_email.delay.assert_called_once_with("foo@bar.com")
+    unsub_phone.delay.assert_called_once_with("(951) 555-1212", "foo@bar.com")

--- a/app/turnout/api_urls.py
+++ b/app/turnout/api_urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path("integration/", include("integration.api_urls")),
     path("pollingplace/", include("polling_place.api_urls")),
     path("common/", include("common.api_urls")),
+    path("people/", include("people.api_urls")),
 ]


### PR DESCRIPTION
Allow opt-out by email or by phone (or both).

No feedback is provided to the caller.  The AN update is done async in
the appropriate worker queue.